### PR TITLE
fix: decouple schema from db config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	conn "github.com/villaleo/somos-events/db"
-	"github.com/villaleo/somos-events/handlers"
+	conn "github.com/somos831/somos-backend/db"
+	"github.com/somos831/somos-backend/handlers"
 )
 
 func main() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,11 +18,11 @@ func main() {
 
 	dbUser := os.Getenv("DB_USER")
 	dbPassword := os.Getenv("DB_PASSWORD")
-	dbName := os.Getenv("DB_NAME")
-
+	dbName := "somos_events"
 	db := conn.Connect(dbUser, dbPassword, dbName)
-	conn.CreateTables(db)
+
 	defer conn.Disconnect(db)
+	conn.ExecuteSchemaFromFile(db, "db/schema.sql")
 	handler := handlers.New(db)
 	mux := http.NewServeMux()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	dbUser := os.Getenv("DB_USER")
 	dbPassword := os.Getenv("DB_PASSWORD")
-	dbName := "somos_events"
+	dbName := os.Getenv("DB_NAME")
 	db := conn.Connect(dbUser, dbPassword, dbName)
 
 	defer conn.Disconnect(db)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,5 +1,5 @@
 -- schema.sql
--- defines the schema for the `somos_events` database
+-- defines the schema for the database
 
 CREATE TABLE IF NOT EXISTS categories (
     id INT NOT NULL AUTO_INCREMENT,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,18 @@
+-- schema.sql
+-- defines the schema for the `somos_events` database
+
+CREATE TABLE IF NOT EXISTS categories (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(50) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(50) NOT NULL,
+    description VARCHAR(1000),
+    category_id INT NOT NULL,
+    location VARCHAR(200),
+    PRIMARY KEY (id),
+    FOREIGN KEY (category_id) REFERENCES categories(id)
+);

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/villaleo/somos-events
+module github.com/somos831/somos-backend
 
 go 1.22.1
 

--- a/handlers/category.go
+++ b/handlers/category.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/villaleo/somos-events/errors/httperror"
-	"github.com/villaleo/somos-events/models"
+	"github.com/somos831/somos-backend/errors/httperror"
+	"github.com/somos831/somos-backend/models"
 )
 
 // ListAllCategories lists all the categories in the database.

--- a/handlers/event.go
+++ b/handlers/event.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/villaleo/somos-events/errors/httperror"
-	"github.com/villaleo/somos-events/models"
+	"github.com/somos831/somos-backend/errors/httperror"
+	"github.com/somos831/somos-backend/models"
 )
 
 type eventQueryParams struct {

--- a/models/category.go
+++ b/models/category.go
@@ -1,6 +1,6 @@
 package models
 
-import "github.com/villaleo/somos-events/errors/httperror"
+import "github.com/somos831/somos-backend/errors/httperror"
 
 type Category struct {
 	Id   int    `json:"id"`

--- a/models/event.go
+++ b/models/event.go
@@ -1,6 +1,6 @@
 package models
 
-import "github.com/villaleo/somos-events/errors/httperror"
+import "github.com/somos831/somos-backend/errors/httperror"
 
 type Event struct {
 	Id          int      `json:"id"`


### PR DESCRIPTION
This change closes #3 . It moves the schema config to a new file, `db/schema.sql`.

In addition, the project's module was also renamed from `github.com/villaleo/somos-events` to `github.com/somos831/somos-backend`.